### PR TITLE
quick fix for is_re_worker_active()

### DIFF
--- a/startup/00-startup.py
+++ b/startup/00-startup.py
@@ -24,7 +24,7 @@ from tiled.client import from_uri
 from tiled.server import SimpleTiledServer
 
 RE = RunEngine(RedisJSONDict(redis.Redis("info.tst.nsls2.bnl.gov"), prefix=""))
-if is_re_worker_active():
+if not is_re_worker_active():
     autoawait_in_bluesky_event_loop()
 
 


### PR DESCRIPTION
Within 00-startup.py, changed:

 if is_re_worker_active():

to:

if not is_re_worker_active():

This allows it to work properly for bluesky_queueserver.  
